### PR TITLE
[Update]: apps/io/main.cpp -> MPI Initialisation for subfiling

### DIFF
--- a/apps/io/gys_io.cpp
+++ b/apps/io/gys_io.cpp
@@ -450,10 +450,7 @@ int main(int argc, char **argv) {
    *
    ****************************************/
 
-  #ifdef SSF
-  MPI_Init(&argc, &argv);
-  #endif __SSF__
-
+  
   #ifdef SUBFILING
   int provided;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
@@ -461,7 +458,10 @@ int main(int argc, char **argv) {
     printf("provided level = %d, required level = %d\n", provided, MPI_THREAD_MULTIPLE);
     return EXIT_FAILURE;
   }
-  #endif __SUBFILING__
+  #else
+  MPI_Init(&argc, &argv);
+  #endif
+  
   int rank;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   Kokkos::ScopeGuard scope(argc, argv);

--- a/apps/io/gys_io.cpp
+++ b/apps/io/gys_io.cpp
@@ -449,7 +449,19 @@ int main(int argc, char **argv) {
    *   Main program: mini_app            *
    *
    ****************************************/
+
+  #ifdef SSF
   MPI_Init(&argc, &argv);
+  #endif __SSF__
+
+  #ifdef SUBFILING
+  int provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+  if (provided != MPI_THREAD_MULTIPLE){
+    printf("provided level = %d, required level = %d\n", provided, MPI_THREAD_MULTIPLE);
+    return EXIT_FAILURE;
+  }
+  #endif __SUBFILING__
   int rank;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   Kokkos::ScopeGuard scope(argc, argv);


### PR DESCRIPTION
Keeping the initial declaration of MPI (MPI_Init) into an ifdef block called SSF for the Single Shared File and add the a new initialisation of MPI (MPI_Init_Threads) required for the IOC of subfiling in an ifdef block called SUBFILING.