### PR TITLE
Correct fluid moments iteration

### DIFF
--- a/apps/io/gys_io.cpp
+++ b/apps/io/gys_io.cpp
@@ -145,7 +145,8 @@ IdxRangeSpTor3DV2D initialise_mesh(int rank, PC_tree_t conf_gyselax) {
 
 void update_distribution_fun(DFieldSpGrid allfdistribu,
                              IdxRangeSpTor3DV2D const &mesh,
-                             PC_tree_t conf_gyselax) {
+                             PC_tree_t conf_gyselax,
+                             MPI_Comm comm) {
   // Read species-specific parameters from YAML
   double const L_tor2 = PCpp_double(conf_gyselax, ".SplineMesh.Tor2_max") -
                         PCpp_double(conf_gyselax, ".SplineMesh.Tor2_min");
@@ -155,12 +156,21 @@ void update_distribution_fun(DFieldSpGrid allfdistribu,
 
   // Read shift values from config (default to 0.0 if not present) and add
   // random values
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_real_distribution<double> dis(-1.0, 1.0);
+  int rank;
+  MPI_Comm_rank(comm, &rank);
+  double shifts[2];
+  if (rank == 0) {
+      std::random_device rd;
+      std::mt19937 gen(rd());
+      std::uniform_real_distribution<double> dis(-1.0, 1.0);
+      shifts[0] = dis(gen);
+      shifts[1] = dis(gen);
+  }
+  MPI_Bcast(shifts, 2, MPI_DOUBLE, 0, comm);
 
-  double const shift_tor2 = dis(gen);
-  double const shift_tor3 = dis(gen);
+  double const shift_tor2 = shifts[0];
+  double const shift_tor3 = shifts[1];
+
   ddc::parallel_for_each(
       Kokkos::DefaultExecutionSpace(), mesh,
       KOKKOS_LAMBDA(IdxSpTor3DV2D const ispgrid) {
@@ -553,21 +563,23 @@ int main(int argc, char **argv) {
       // in PDI
       compute_fluid_moments_pycall(rank, local_mesh, global_mesh,
                                    allfdistribu_host);
-      // Create a working copy from the initial distribution
+      // Create a working copy from the current distribution
       ddc::parallel_deepcopy(
           allfdistribu_work,
-          allfdistribu); // alldistribu_work <--- allfdistribu
+          allfdistribu_host); // alldistribu_work <--- allfdistribu
       // Update the working copy (not the original)
       if (rank == 0) {
         cout << "Updating distribution function" << endl;
       }
       update_distribution_fun(get_field(allfdistribu_work), local_mesh,
-                              configs.conf_gyselax);
+                              configs.conf_gyselax, MPI_COMM_WORLD);
       // Copy the working copy to the host (needed for PDI)
       ddc::parallel_deepcopy(
           allfdistribu_host,
           allfdistribu_work); // alldistribu_host <--- allfdistribu_work
     }
+    ddc::parallel_deepcopy(allfdistribu,
+                           allfdistribu_host); // alldistribu_host <--- allfdistribu
     // ------------------------------------------------------------------------------
   }
   time_points[2] = steady_clock::now();


### PR DESCRIPTION
- [x] At each iteration of the fluid moments computation with pycall, the distribution function is reinitialized, so the same moments are computed each time.

- [x] The random parameter used for the update of the distribution function is different for each MPI rank, so the resulting updated distribution function is not coherent
