### PR TITLE
Refactor restart procedure of the offline compression pipeline

### DIFF
--- a/apps/compression/gys_compress.cpp
+++ b/apps/compression/gys_compress.cpp
@@ -296,6 +296,11 @@ int main(int argc, char **argv) {
     compression_period = static_cast<int>(
         PCpp_int(configs.conf_gyselax, ".CompressionBenchmark.compression_period"));
   }
+  int compression_mode = 0;  // 0 = none, 1 = online (pycall), 2 = offline (deisa-dask)
+  if (!PC_status(PC_get(configs.conf_gyselax, ".CompressionBenchmark.compression_mode"))) {
+    compression_mode = static_cast<int>(
+        PCpp_int(configs.conf_gyselax, ".CompressionBenchmark.compression_mode"));
+  }
 
   if (rank == 0) {
     std::cout << "Input fdistribu file name: " << fdistribu_filename
@@ -422,6 +427,7 @@ int main(int argc, char **argv) {
   expose_mesh_to_pdi("MeshVy", idxrange_vy);
   ddc::expose_to_pdi("nbstep_diag", nbstep_diag);
   ddc::expose_to_pdi("nb_step_compression", compression_period);
+  ddc::expose_to_pdi("compression_mode", compression_mode);
   ddc::expose_to_pdi("deltat", deltat);
   ddc::expose_to_pdi("Nkinspecies", idx_range_kinsp.size());
   ddc::expose_to_pdi("fdistribu_charges",

--- a/apps/compression/launch_benchmark.py
+++ b/apps/compression/launch_benchmark.py
@@ -296,14 +296,14 @@ def stop_dask(sch_proc, worker_proc):
 def print_branch_banner(branch_name):
     label = f" {branch_name} "
     width = max(70, len(label) + 4)
-    bar = "═" * (width - 2)
+    bar = "=" * (width - 2)
     cyan = "\033[96m"
     bold = "\033[1m"
     reset = "\033[0m"
     print()
-    print(f"{cyan}{bold}╔{bar}╗{reset}")
-    print(f"{cyan}{bold}║{label.center(width - 2)}║{reset}")
-    print(f"{cyan}{bold}╚{bar}╝{reset}")
+    print(f"{cyan}{bold}+{bar}+{reset}")
+    print(f"{cyan}{bold}|{label.center(width - 2)}|{reset}")
+    print(f"{cyan}{bold}+{bar}+{reset}")
     print()
 
 

--- a/apps/compression/launch_benchmark.py
+++ b/apps/compression/launch_benchmark.py
@@ -56,35 +56,6 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--keep-payloads",
-        action="store_true",
-        help=(
-            "Keep restart_iter_XXXXX_compressed.npz payload files. "
-            "By default, they are deleted after their size and metrics are "
-            "stored in compression_events.yaml."
-        ),
-    )
-
-    parser.add_argument(
-        "--keep-restart-approximations",
-        action="store_true",
-        help=(
-            "Keep restart_iter_XXXXX_approx.h5 files after they have been "
-            "used for restart. By default, each approximation is deleted after "
-            "the segment that consumes it has finished."
-        ),
-    )
-
-    parser.add_argument(
-        "--keep-segment-configs",
-        action="store_true",
-        help=(
-            "Keep config_compressed_segment_XXX.yaml files. "
-            "By default, segment configs are removed after each segment run."
-        ),
-    )
-
-    parser.add_argument(
         "--keep-pdi-copy",
         action="store_true",
         help=(
@@ -248,7 +219,8 @@ def create_yaml_override(
     fdist_file,
     nbiter,
     iter_offset,
-    compression_period_online=0,
+    compression_period=0,
+    compression_mode=0,
 ):
     with open(base_yaml_path, "r") as f:
         config = yaml.safe_load(f)
@@ -262,7 +234,8 @@ def create_yaml_override(
     config["Algorithm"]["nbiter"] = nbiter
 
     config.setdefault("CompressionBenchmark", {})
-    config["CompressionBenchmark"]["compression_period"] = compression_period_online
+    config["CompressionBenchmark"]["compression_period"] = compression_period
+    config["CompressionBenchmark"]["compression_mode"] = compression_mode
 
     with open(output_yaml_path, "w") as f:
         yaml.dump(config, f, default_flow_style=False)
@@ -342,6 +315,19 @@ def stop_dask(sch_proc, worker_proc):
             except ProcessLookupError:
                 pass
 
+def print_branch_banner(branch_name):
+    label = f" {branch_name} "
+    width = max(70, len(label) + 4)
+    bar = "═" * (width - 2)
+    cyan = "\033[96m"
+    bold = "\033[1m"
+    reset = "\033[0m"
+    print()
+    print(f"{cyan}{bold}╔{bar}╗{reset}")
+    print(f"{cyan}{bold}║{label.center(width - 2)}║{reset}")
+    print(f"{cyan}{bold}╚{bar}╝{reset}")
+    print()
+
 
 def run_sim_with_diagnostics(branch_name, gysela_yaml, pdi_yaml, work_dir, n_workers=1):
     """Start Dask, run simulation and diagnostics in parallel, stop Dask.
@@ -349,7 +335,7 @@ def run_sim_with_diagnostics(branch_name, gysela_yaml, pdi_yaml, work_dir, n_wor
     Both the simulation and diagnostics.py run with work_dir as CWD so that
     HDF5 snapshots and diagnostics.csv are written there.
     """
-    print(f"\n--- Running: {branch_name} ---")
+    print_branch_banner(branch_name)
     os.makedirs(work_dir, exist_ok=True)
 
     deisa_env = load_deisa_env()
@@ -426,156 +412,42 @@ def run_baseline(run_dir, run_pdi_yaml, iter_total, n_workers=1):
     return dir_baseline
 
 
-def run_periodic_compressed_branch(
-    run_dir,
-    run_pdi_yaml,
-    iter_total,
-    compression_period,
-    n_workers=1,
-    keep_payloads=False,
-    keep_restart_approximations=False,
-    keep_segment_configs=False,
-):
-    dir_compressed = os.path.join(run_dir, "branch_compressed")
-    restart_dir = os.path.join(run_dir, "periodic_restarts")
+def run_offline_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, n_workers=1):
+    dir_offline = os.path.join(run_dir, "branch_offline_compressed")
+    yaml_offline = os.path.join(run_dir, "config_offline_compressed.yaml")
 
-    os.makedirs(dir_compressed, exist_ok=True)
-    os.makedirs(restart_dir, exist_ok=True)
+    create_yaml_override(
+        SOURCE_GYSELA_YAML,
+        yaml_offline,
+        nb_restart=0,
+        fdist_file="none",
+        nbiter=iter_total,
+        iter_offset=0,
+        compression_period=compression_period,
+        compression_mode=2,
+    )
 
-    current_iter = 0
-    segment_id = 0
-    restart_file = "none"
-    compression_events = []
+    run_sim_with_diagnostics(
+        branch_name="Offline compressed",
+        gysela_yaml=yaml_offline,
+        pdi_yaml=run_pdi_yaml,
+        work_dir=dir_offline,
+        n_workers=n_workers,
+    )
 
-    while current_iter < iter_total:
-        remaining_iter = iter_total - current_iter
-        segment_nbiter = min(compression_period, remaining_iter)
-        next_iter = current_iter + segment_nbiter
+    events = _collect_offline_compression_events(dir_offline)
+    write_compression_manifest(run_dir, events)
 
-        yaml_segment = os.path.join(
-            run_dir,
-            f"config_compressed_segment_{segment_id:03d}.yaml",
-        )
+    return dir_offline
 
-        nb_restart = 0 if segment_id == 0 else segment_id
-        restart_file_used_by_segment = restart_file
 
-        create_yaml_override(
-            SOURCE_GYSELA_YAML,
-            yaml_segment,
-            nb_restart=nb_restart,
-            fdist_file=restart_file,
-            nbiter=segment_nbiter,
-            iter_offset=current_iter,
-        )
+def _collect_offline_compression_events(work_dir):
+    csv_path = os.path.join(work_dir, "compression_events_offline.csv")
+    if not os.path.exists(csv_path):
+        return []
+    with open(csv_path, newline="") as fh:
+        return [dict(row) for row in csv.DictReader(fh)]
 
-        run_sim_with_diagnostics(
-            branch_name=(f"Compressed segment {segment_id} ({current_iter} -> {next_iter})"),
-            gysela_yaml=yaml_segment,
-            pdi_yaml=run_pdi_yaml,
-            work_dir=dir_compressed,
-            n_workers=n_workers,
-        )
-
-        if nb_restart > 0 and not keep_restart_approximations:
-            remove_file_if_exists(
-                restart_file_used_by_segment,
-                "consumed restart approximation",
-            )
-
-        if not keep_segment_configs:
-            remove_file_if_exists(
-                yaml_segment,
-                "temporary compressed-segment config",
-            )
-
-        current_iter = next_iter
-
-        if current_iter >= iter_total:
-            break
-
-        if current_iter % compression_period != 0:
-            raise RuntimeError(
-                f"Cannot compress at iteration {current_iter}: "
-                f"not a multiple of compression_period={compression_period}."
-            )
-
-        raw_restart = os.path.join(
-            dir_compressed,
-            f"GYSELALIBXX_{current_iter:05d}.h5",
-        )
-
-        approx_restart = os.path.join(
-            restart_dir,
-            f"restart_iter_{current_iter:05d}_approx.h5",
-        )
-
-        compressed_payload = os.path.join(
-            restart_dir,
-            f"restart_iter_{current_iter:05d}_compressed.npz",
-        )
-
-        assert_file_exists(
-            raw_restart,
-            f"restart source file at iteration {current_iter}",
-        )
-
-        raw_restart_size = os.path.getsize(raw_restart)
-
-        metrics = compress_decompress(
-            input_h5=raw_restart,
-            output_h5=approx_restart,
-            compressed_path=compressed_payload,
-        )
-
-        approx_restart_size = os.path.getsize(approx_restart) if os.path.exists(approx_restart) else None
-
-        compressed_payload_size = os.path.getsize(compressed_payload) if os.path.exists(compressed_payload) else None
-
-        compression_events.append(
-            {
-                "segment_id": segment_id,
-                "iteration": current_iter,
-                "file_index": current_iter,
-                "branch_restart": os.path.relpath(raw_restart, run_dir),
-                "approx_restart": os.path.relpath(approx_restart, run_dir),
-                "compressed_payload": (os.path.relpath(compressed_payload, run_dir) if keep_payloads else None),
-                "method_name": metrics.get("method_name"),
-                "param_names": metrics.get("param_names", []),
-                "params": metrics.get("params", {}),
-                "n_components": metrics.get("param_n_components"),
-                "raw_restart_size": raw_restart_size,
-                "approx_restart_size": approx_restart_size,
-                "compressed_payload_size": compressed_payload_size,
-                "explained_variance_ratio_sum": metrics.get("explained_variance_ratio_sum"),
-                "relative_l2_error": float(metrics["relative_l2_error"]),
-                "max_abs_error": float(metrics["max_abs_error"]),
-                "mean_abs_error": float(metrics["mean_abs_error"]),
-                "rmse": float(metrics["rmse"]),
-                "compression_seconds": metrics.get("compression_seconds"),
-                "decompression_seconds": metrics.get("decompression_seconds"),
-                "compression_ratio": (
-                    None if metrics["compression_ratio"] is None else float(metrics["compression_ratio"])
-                ),
-                "approx_restart_kept": keep_restart_approximations,
-                "compressed_payload_kept": keep_payloads,
-            }
-        )
-
-        if not keep_payloads:
-            remove_file_if_exists(
-                compressed_payload,
-                "compressed PCA payload",
-            )
-
-        remove_file_if_exists(raw_restart, "consumed raw restart")
-
-        restart_file = os.path.abspath(approx_restart)
-        segment_id += 1
-
-    write_compression_manifest(run_dir, compression_events)
-
-    return dir_compressed
 
 def run_online_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, n_workers=1):
     dir_online = os.path.join(run_dir, "branch_online_compressed")
@@ -588,7 +460,8 @@ def run_online_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_
         fdist_file="none",
         nbiter=iter_total,
         iter_offset=0,
-        compression_period_online=compression_period,
+        compression_period=compression_period,
+        compression_mode=1,
     )
 
     run_sim_with_diagnostics(
@@ -683,21 +556,16 @@ def main():
             n_workers=args.dask_workers,
         )
     else:
-        run_periodic_compressed_branch(
+        run_offline_compressed_branch(
             run_dir=run_dir,
             run_pdi_yaml=run_pdi_yaml,
             iter_total=iter_total,
             compression_period=compression_period,
             n_workers=args.dask_workers,
-            keep_payloads=args.keep_payloads,
-            keep_restart_approximations=args.keep_restart_approximations,
-            keep_segment_configs=args.keep_segment_configs,
         )
 
     if not args.keep_pdi_copy:
         remove_file_if_exists(run_pdi_yaml, "copied PDI config")
-
-    
 
     print(f"\nWorkflow complete. All files are in: {run_dir}")
     return run_dir

--- a/apps/compression/launch_benchmark.py
+++ b/apps/compression/launch_benchmark.py
@@ -15,7 +15,6 @@ import csv
 # Compression params / names
 # ------------------------------------------------------------------
 from evaluate_compression import plot_diags
-from compression_config import build_offline_compressor
 
 
 EXEC_CMD = ["mpirun", "-n", "4", "./build/apps/compression/gys_compress"]
@@ -191,43 +190,6 @@ def format_param_summary(metrics):
     return ", ".join(f"{key}={value}" for key, value in params.items())
 
 
-def compress_decompress(input_h5, output_h5, compressed_path, compressor_kwargs):
-    compressor = build_offline_compressor(**compressor_kwargs)
-
-    print(
-        f"  [{compressor.method_name} Compression] "
-        f"{os.path.basename(input_h5)} -> {os.path.basename(output_h5)}"
-    )
-    print(f"  [Parameters] {compressor.printable_name()}")
-    print(f"  [Compressed Payload] {os.path.basename(compressed_path)}")
-
-    metrics = compressor.compress_decompress_h5(
-        input_h5=input_h5,
-        output_h5=output_h5,
-        compressed_path=compressed_path,
-    )
-
-    print(f"  Method = {metrics['method_name']} ({format_param_summary(metrics)})")
-
-    explained = metrics.get("explained_variance_ratio_sum")
-    if explained is not None:
-        print(f"  Explained variance ratio sum = {explained:.12e}")
-
-    print("  Relative L2 reconstruction error = " f"{metrics['relative_l2_error']:.12e}")
-    print("  Max abs reconstruction error = " f"{metrics['max_abs_error']:.12e}")
-
-    if metrics.get("mean_abs_error") is not None:
-        print("  Mean abs reconstruction error = " f"{metrics['mean_abs_error']:.12e}")
-
-    if metrics.get("rmse") is not None:
-        print("  RMSE reconstruction error = " f"{metrics['rmse']:.12e}")
-
-    if metrics["compression_ratio"] is not None:
-        print(f"  Compression ratio = {metrics['compression_ratio']:.6f}x")
-
-    return metrics
-
-
 def create_yaml_override(
     base_yaml_path,
     output_yaml_path,
@@ -345,7 +307,7 @@ def print_branch_banner(branch_name):
     print()
 
 
-def run_sim_with_diagnostics(branch_name, gysela_yaml, pdi_yaml, work_dir, n_workers=1):
+def run_sim_with_diagnostics(branch_name, gysela_yaml, pdi_yaml, work_dir, n_workers=1, extra_env=None):
     """Start Dask, run simulation and diagnostics in parallel, stop Dask.
 
     Both the simulation and diagnostics.py run with work_dir as CWD so that
@@ -356,6 +318,10 @@ def run_sim_with_diagnostics(branch_name, gysela_yaml, pdi_yaml, work_dir, n_wor
 
     deisa_env = load_deisa_env()
     sch_proc, worker_proc, deisa_env = start_dask(deisa_env, n_workers)
+
+    if extra_env:
+        deisa_env = dict(deisa_env)
+        deisa_env.update({k: str(v) for k, v in extra_env.items()})
 
     try:
         exec_path = os.path.abspath(EXEC_CMD[-1])
@@ -428,7 +394,7 @@ def run_baseline(run_dir, run_pdi_yaml, iter_total, n_workers=1):
     return dir_baseline
 
 
-def run_offline_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, n_workers=1):
+def run_offline_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, mesh_kwargs=None, n_workers=1):
     dir_offline = os.path.join(run_dir, "branch_offline_compressed")
     yaml_offline = os.path.join(run_dir, "config_offline_compressed.yaml")
 
@@ -443,12 +409,15 @@ def run_offline_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression
         compression_mode=2,
     )
 
+    extra_env = {"COMPRESSION_MESH_KWARGS": json.dumps(mesh_kwargs)} if mesh_kwargs else None
+
     run_sim_with_diagnostics(
         branch_name="Offline compressed",
         gysela_yaml=yaml_offline,
         pdi_yaml=run_pdi_yaml,
         work_dir=dir_offline,
         n_workers=n_workers,
+        extra_env=extra_env,
     )
 
     events = _collect_offline_compression_events(dir_offline)

--- a/apps/compression/pdi_out_diags.yaml
+++ b/apps/compression/pdi_out_diags.yaml
@@ -131,7 +131,7 @@ plugins:
             # Offline Compression
             elif int(compression_mode) == 2:
               bridge.send("fdistribu_offline", fdistribu, timestep)
-              deadline = time.time() + 60.0
+              deadline = time.time() + 300.0
               done = False
               while not done:
                 try:

--- a/apps/compression/pdi_out_diags.yaml
+++ b/apps/compression/pdi_out_diags.yaml
@@ -85,6 +85,7 @@ plugins:
           import compression_diagnostics
           import pdi
           comm = MPI.COMM_WORLD
+          rank = comm.Get_rank()
       InitBridge:
         with: { global_fdistribu_extents: $global_fdistribu_extents,
                 local_fdistribu_extents: $local_fdistribu_extents,
@@ -144,7 +145,9 @@ plugins:
                     )
                   time.sleep(0.05)
               pdi.event("read_compressed_fdistribu")
-          print(f"--------------------------timestep: {timestep}")
+          if timestep % 10 == 0:
+            if rank == 0:
+              print(f"--------------------------timestep: {timestep}")
           if timestep % int(nbstep_diag) == 0:
             # ===== will no longer be needed once xarrays can be sent through the bridge ======
             if comm.Get_rank() == 0:

--- a/apps/compression/pdi_out_diags.yaml
+++ b/apps/compression/pdi_out_diags.yaml
@@ -12,6 +12,7 @@ metadata:
   absolute_time: double
   nbstep_diag: int
   nb_step_compression: int
+  compression_mode: int
   iter_saved : int
   MeshX_extents: { type: array, subtype: int64, size: 1 }
   MeshX:
@@ -77,10 +78,12 @@ plugins:
       Init:
         with: {}
         exec: |
+          import time
           import numpy as np
           from mpi4py import MPI
           from deisa.dask import Bridge
           import compression_diagnostics
+          import pdi
           comm = MPI.COMM_WORLD
       InitBridge:
         with: { global_fdistribu_extents: $global_fdistribu_extents,
@@ -97,6 +100,11 @@ plugins:
                   'chunk_shape':    local_shape,
                   'chunk_position': chunk_pos,
               },
+              'fdistribu_offline': {
+                  'global_shape':   global_shape,
+                  'chunk_shape':    local_shape,
+                  'chunk_position': chunk_pos,
+              },
           }
           bridge = Bridge(comm, arrays_metadata)
       iteration:
@@ -107,6 +115,7 @@ plugins:
           iter_offset: $iter_offset
           nbstep_diag: $nbstep_diag
           nb_step_compression: $nb_step_compression
+          compression_mode: $compression_mode
           MeshX: $MeshX
           MeshY: $MeshY
           MeshVx: $MeshVx
@@ -114,8 +123,27 @@ plugins:
         exec: |
           timestep = int(it) + int(iter_offset)
 
-          if int(nb_step_compression) > 0 and timestep % int(nb_step_compression) == 0:
-            compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank())
+          if int(nb_step_compression) > 0 and timestep > 0 and timestep % int(nb_step_compression) == 0:
+            # Online Compression
+            if int(compression_mode) == 1:
+              compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank())
+            # Offline Compression
+            elif int(compression_mode) == 2:
+              bridge.send("fdistribu_offline", fdistribu, timestep)
+              deadline = time.time() + 60.0
+              done = False
+              while not done:
+                try:
+                  done = bool(bridge.get("fdistribu_offline_done", timestep=timestep))
+                except KeyError:
+                  done = False
+                if not done:
+                  if time.time() > deadline:
+                    raise RuntimeError(
+                      f"Timed out waiting for offline compression feedback at iter {timestep}"
+                    )
+                  time.sleep(0.05)
+              pdi.event("read_compressed_fdistribu")
 
           if timestep % int(nbstep_diag) == 0:
             # ===== will no longer be needed once xarrays can be sent through the bridge ======
@@ -139,6 +167,7 @@ plugins:
           t: $absolute_time
           iter_offset: $iter_offset
           nb_step_compression: $nb_step_compression
+          compression_mode: $compression_mode
           MeshX: $MeshX
           MeshY: $MeshY
           MeshVx: $MeshVx
@@ -146,8 +175,27 @@ plugins:
         exec: |
           timestep = int(it) + int(iter_offset)
 
-          if int(nb_step_compression) > 0 and timestep % int(nb_step_compression) == 0:
-            compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank())
+          if int(nb_step_compression) > 0 and timestep > 0 and timestep % int(nb_step_compression) == 0:
+            # Online Compression
+            if int(compression_mode) == 1:
+              compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank())
+            # Offline Compression
+            elif int(compression_mode) == 2:
+              bridge.send("fdistribu_offline", fdistribu, timestep)
+              deadline = time.time() + 60.0
+              done = False
+              while not done:
+                try:
+                  done = bool(bridge.get("fdistribu_offline_done", timestep=timestep))
+                except KeyError:
+                  done = False
+                if not done:
+                  if time.time() > deadline:
+                    raise RuntimeError(
+                      f"Timed out waiting for offline compression feedback at iter {timestep}"
+                    )
+                  time.sleep(0.05)
+              pdi.event("read_compressed_fdistribu")
 
           # ===== will no longer be needed once xarrays can be sent through the bridge ======
           if comm.Get_rank() == 0:
@@ -196,6 +244,19 @@ plugins:
           dataset_selection:
             size: [ '$local_fdistribu_extents[0]', '$local_fdistribu_extents[1]', '$local_fdistribu_extents[2]', '$local_fdistribu_extents[3]', '$local_fdistribu_extents[4]' ]
             start: ['$local_fdistribu_starts[0]', '$local_fdistribu_starts[1]', '$local_fdistribu_starts[2]', '$local_fdistribu_starts[3]', '$local_fdistribu_starts[4]']
+    - file: 'GYSELALIBXX_compressed_${iter_saved:05}.h5'
+      communicator: $MPI_COMM_WORLD
+      on_event: [read_compressed_fdistribu]
+      datasets:
+        fdistribu:
+          type: array
+          subtype: double
+          size: ['$Nkinspecies', '$MeshX_extents[0]', '$MeshY_extents[0]', '$MeshVx_extents[0]', '$MeshVy_extents[0]']
+      read:
+        fdistribu:
+          dataset_selection:
+            size: [ '$local_fdistribu_extents[0]', '$local_fdistribu_extents[1]', '$local_fdistribu_extents[2]', '$local_fdistribu_extents[3]', '$local_fdistribu_extents[4]' ]
+            start: [ '$local_fdistribu_starts[0]', '$local_fdistribu_starts[1]', '$local_fdistribu_starts[2]', '$local_fdistribu_starts[3]', '$local_fdistribu_starts[4]' ]
     - file: 'GYSELALIBXX_initstate.h5'
       on_event: [initial_state]
       collision_policy: replace_and_warn

--- a/src/python/compression_config.py
+++ b/src/python/compression_config.py
@@ -1,5 +1,6 @@
 """Compressor selection for the offline and online compression pipelines."""
 
+import inspect
 from compression_methods.PCA import PCACompressor
 from compression_methods.random_noise import RandomNoiseCompressor
 from compression_methods.neural_network import NeuralNetworkCompressor
@@ -18,7 +19,7 @@ OFFLINE_COMPRESSOR_CLASS = NeuralNetworkCompressor
 OFFLINE_COMPRESSOR_PARAMS = {
     "arch": "periodic_siren_deep_128",
     "lr": 1e-3,
-    "max_iters": 2000,
+    "max_iters": 500,
     "batch_size": 2000,
     "lbfgs_iters": 50,
 }
@@ -28,13 +29,10 @@ ONLINE_COMPRESSOR_PARAMS = {
    "relative_noise_level": 0.01,
 }
 
-"""
-def build_offline_compressor():
-    return OFFLINE_COMPRESSOR_CLASS(**OFFLINE_COMPRESSOR_PARAMS)
-
-"""
 def build_offline_compressor(**overrides):
-    params = {**OFFLINE_COMPRESSOR_PARAMS, **overrides}
+    accepted = set(inspect.signature(OFFLINE_COMPRESSOR_CLASS.__init__).parameters) - {"self"}
+    filtered = {k: v for k, v in overrides.items() if k in accepted}
+    params = {**OFFLINE_COMPRESSOR_PARAMS, **filtered}
     return OFFLINE_COMPRESSOR_CLASS(**params)
 
 def build_online_compressor():

--- a/src/python/compression_config.py
+++ b/src/python/compression_config.py
@@ -25,7 +25,7 @@ OFFLINE_COMPRESSOR_PARAMS = {
 
 ONLINE_COMPRESSOR_CLASS = RandomNoiseCompressor
 ONLINE_COMPRESSOR_PARAMS = {
-   "latent_dim": 16,
+   "relative_noise_level": 0.01,
 }
 
 """

--- a/src/python/compression_diagnostics.py
+++ b/src/python/compression_diagnostics.py
@@ -1,7 +1,9 @@
 """Compression logic shared by the rank-local online path and the bridge-based offline path:
 builds compressors, runs compress/decompress round trips, and logs results to CSV."""
 
+import os
 import csv
+import json
 import h5py
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,7 +31,8 @@ def get_compression_config(data_dir="."):
 def get_offline_compression_config(data_dir="."):
     global _OFFLINE_COMPRESSION_CFG
     if _OFFLINE_COMPRESSION_CFG is None:
-        _OFFLINE_COMPRESSION_CFG = CompressionConfig(Path(data_dir), build_offline_compressor())
+        mesh_kwargs = json.loads(os.environ.get("COMPRESSION_MESH_KWARGS", "{}"))
+        _OFFLINE_COMPRESSION_CFG = CompressionConfig(Path(data_dir), build_offline_compressor(**mesh_kwargs))
     return _OFFLINE_COMPRESSION_CFG
 
 

--- a/src/python/compression_diagnostics.py
+++ b/src/python/compression_diagnostics.py
@@ -1,11 +1,12 @@
-"""In-situ online compression: Mutates fdistribu in place.
-"""
+"""Compression logic shared by the rank-local online path and the bridge-based offline path:
+builds compressors, runs compress/decompress round trips, and logs results to CSV."""
 
 import csv
+import h5py
 from dataclasses import dataclass
 from pathlib import Path
 
-from compression_config import build_online_compressor
+from compression_config import build_online_compressor, build_offline_compressor
 
 
 @dataclass
@@ -15,6 +16,7 @@ class CompressionConfig:
 
 
 _COMPRESSION_CFG = None
+_OFFLINE_COMPRESSION_CFG = None
 
 
 def get_compression_config(data_dir="."):
@@ -22,6 +24,22 @@ def get_compression_config(data_dir="."):
     if _COMPRESSION_CFG is None:
         _COMPRESSION_CFG = CompressionConfig(Path(data_dir), build_online_compressor())
     return _COMPRESSION_CFG
+
+
+def get_offline_compression_config(data_dir="."):
+    global _OFFLINE_COMPRESSION_CFG
+    if _OFFLINE_COMPRESSION_CFG is None:
+        _OFFLINE_COMPRESSION_CFG = CompressionConfig(Path(data_dir), build_offline_compressor())
+    return _OFFLINE_COMPRESSION_CFG
+
+
+def _write_compression_event_csv(event_path, record):
+    write_header = not event_path.is_file()
+    with open(event_path, mode="a", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=record.keys())
+        if write_header:
+            writer.writeheader()
+        writer.writerow(record)
 
 
 def apply_online_compression(fdistribu, timestep, rank):
@@ -39,11 +57,36 @@ def apply_online_compression(fdistribu, timestep, rank):
     for key, value in (metrics.get("params") or {}).items():
         record[f"param_{key}"] = value
 
-    write_header = not event_path.is_file()
-    with open(event_path, mode="a", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=record.keys())
-        if write_header:
-            writer.writeheader()
-        writer.writerow(record)
-
+    _write_compression_event_csv(event_path, record)
     return fdistribu
+
+
+def _offline_compressed_restart_path(data_dir, timestep):
+    return Path(data_dir) / f"GYSELALIBXX_compressed_{timestep:05d}.h5"
+
+
+def run_offline_compression_on_global_array(fdistribu_global, timestep, data_dir="."):
+    """Compress the globally assembled array and write the
+    reconstruction to HDF5.
+    """
+    cfg = get_offline_compression_config(data_dir)
+
+    _coefficients, reconstructed = cfg.compressor.compress_decompress_array(fdistribu_global)
+    metrics = cfg.compressor.compute_metrics(
+        f_original=fdistribu_global,
+        f_reconstructed=reconstructed,
+    )
+
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    out_path = _offline_compressed_restart_path(cfg.data_dir, timestep)
+    with h5py.File(out_path, "w") as h5:
+        h5.create_dataset("fdistribu", data=reconstructed)
+
+    event_path = cfg.data_dir / "compression_events_offline.csv"
+    record = {"iter": timestep}
+    record.update({k: v for k, v in metrics.items() if k != "params"})
+    for key, value in (metrics.get("params") or {}).items():
+        record[f"param_{key}"] = value
+    _write_compression_event_csv(event_path, record)
+
+    return out_path

--- a/src/python/diagnostics.py
+++ b/src/python/diagnostics.py
@@ -9,6 +9,8 @@ import numpy as np
 from deisa.dask import Deisa
 from distributed import get_client
 
+import compression_diagnostics
+
 _MEASURE_CFG = None
 
 
@@ -191,6 +193,14 @@ def measure(cfg, f, Efield, it, t_actual):
 
 deisa = Deisa()
 
+@deisa.register("fdistribu_offline")
+def compute_offline_compression(fdistribu_chunks):
+    timestep = int(fdistribu_chunks[0].t)
+    fdistribu_global = np.array(fdistribu_chunks[0])
+
+    compression_diagnostics.run_offline_compression_on_global_array(fdistribu_global, timestep)
+
+    deisa.set("fdistribu_offline_done", True, timestep=timestep)
 
 @deisa.register("fdistribu")
 def compute_diagnostics(fdistribu_chunks):

--- a/src/tests/test_inr_compressor.py
+++ b/src/tests/test_inr_compressor.py
@@ -64,7 +64,7 @@ def test_inr_plumbing():
         f"Model error : expected {n_species} models, got {len(compressed_dict['models'])}"
     print("[OK] The correct number of models has been generated.")
     
-    #verification of the decreasing of th loss 
+    #verification of the decreasing of the loss 
     metrics = compressor.get_extra_metrics()
     final_losses = metrics["final_loss_per_species"]
     assert final_losses is not None and len(final_losses) == n_species, "The losses were not properly recorded."


### PR DESCRIPTION
Read the distribution function from the PDI pycall block instead of initiating a restart procedure on the c++ / launcher side.
Orchestrate the whole pipeline using PDI and pycall blocks isntead of succesive restarts of the simulation.

Depends on #35 