### PR TITLE
40 include deisa dasks send for non distributed arrays

### DIFF
--- a/apps/compression/pdi_out_diags.yaml
+++ b/apps/compression/pdi_out_diags.yaml
@@ -80,12 +80,21 @@ plugins:
           from mpi4py import MPI
           from deisa.dask import Bridge
           comm = MPI.COMM_WORLD
+          rank = comm.Get_rank()
       InitBridge:
         with: { global_fdistribu_extents: $global_fdistribu_extents,
                 local_fdistribu_extents: $local_fdistribu_extents,
-                local_fdistribu_starts: $local_fdistribu_starts
+                local_fdistribu_starts: $local_fdistribu_starts,
+                MeshX_extents: $MeshX_extents,
+                MeshY_extents: $MeshY_extents,
+                MeshVx_extents: $MeshVx_extents,
+                MeshVy_extents: $MeshVy_extents
               }
         exec: |
+          Nx  = int(MeshX_extents[0])
+          Ny  = int(MeshY_extents[0])
+          Nvx = int(MeshVx_extents[0])
+          Nvy = int(MeshVy_extents[0])
           global_shape = tuple(int(x) for x in global_fdistribu_extents)
           local_shape  = tuple(int(x) for x in local_fdistribu_extents)
           chunk_pos    = tuple((local_fdistribu_starts // local_fdistribu_extents).astype(int).tolist())
@@ -96,6 +105,21 @@ plugins:
                   'chunk_position': chunk_pos,
               },
           }
+
+          if rank == 0:
+            non_dist_arrays = {
+                'absolute_time': {
+                    'global_shape':   (1,),
+                    'chunk_shape':    (1,),
+                    'chunk_position': (0,),
+                },
+                'MeshX':  {'global_shape': (Nx,),  'chunk_shape': (Nx,),  'chunk_position': (0,)},
+                'MeshY':  {'global_shape': (Ny,),  'chunk_shape': (Ny,),  'chunk_position': (0,)},
+                'MeshVx': {'global_shape': (Nvx,), 'chunk_shape': (Nvx,), 'chunk_position': (0,)},
+                'MeshVy': {'global_shape': (Nvy,), 'chunk_shape': (Nvy,), 'chunk_position': (0,)},
+            }
+            arrays_metadata = dict(arrays_metadata, **non_dist_arrays)
+
           bridge = Bridge(comm, arrays_metadata)
       iteration:
         with:
@@ -111,20 +135,13 @@ plugins:
         exec: |
           timestep = int(it) + int(iter_offset)
           if timestep % int(nbstep_diag) == 0:
-            # ===== will no longer be needed once xarrays can be sent through the bridge ======
-            if comm.Get_rank() == 0:
-              client = bridge.client
-              client.publish_dataset(coords={
-                'MeshX':  np.array(MeshX),
-                'MeshY':  np.array(MeshY),
-                'MeshVx': np.array(MeshVx),
-                'MeshVy': np.array(MeshVy),
-                'iter': timestep,
-                'absolute_time': np.array([float(t)]),
-              }, override=True)
-            comm.Barrier()
-            # =================================================================================
             bridge.send("fdistribu", fdistribu, timestep)
+            if rank == 0:
+              bridge.send("absolute_time", np.array([float(t)]), timestep)
+              bridge.send("MeshX",  np.array(MeshX),  timestep)
+              bridge.send("MeshY",  np.array(MeshY),  timestep)
+              bridge.send("MeshVx", np.array(MeshVx), timestep)
+              bridge.send("MeshVy", np.array(MeshVy), timestep)
       last_iteration:
         with:
           fdistribu: $fdistribu
@@ -137,20 +154,13 @@ plugins:
           MeshVy: $MeshVy
         exec: |
           timestep = int(it) + int(iter_offset)
-          # ===== will no longer be needed once xarrays can be sent through the bridge ======
-          if comm.Get_rank() == 0:
-            client = bridge.client
-            client.publish_dataset(coords={
-              'MeshX':  np.array(MeshX),
-              'MeshY':  np.array(MeshY),
-              'MeshVx': np.array(MeshVx),
-              'MeshVy': np.array(MeshVy),
-              'iter': timestep,
-              'absolute_time': np.array([float(t)]),
-            }, override=True)
-          comm.Barrier()
-          # =================================================================================
           bridge.send("fdistribu", fdistribu, timestep)
+          if rank == 0:
+            bridge.send("absolute_time", np.array([float(t)]), timestep)
+            bridge.send("MeshX",  np.array(MeshX),  timestep)
+            bridge.send("MeshY",  np.array(MeshY),  timestep)
+            bridge.send("MeshVx", np.array(MeshVx), timestep)
+            bridge.send("MeshVy", np.array(MeshVy), timestep)
       EndSimulation:
         with:
           it: $iter

--- a/src/python/diagnostics.py
+++ b/src/python/diagnostics.py
@@ -11,7 +11,6 @@ from distributed import get_client
 
 _MEASURE_CFG = None
 
-
 @dataclass
 class PathsConfig:
     data_dir: Path
@@ -75,10 +74,6 @@ class Config:
     grid:  GridConfig
 
 
-def to_dask(array):
-    return array if isinstance(array, da.Array) else da.from_array(array)
-
-
 def init_measure_config(x, y, vx, vy, data_dir="."):
     global _MEASURE_CFG
     _MEASURE_CFG = Config(PathsConfig(Path(data_dir)), GridConfig(x, y, vx, vy))
@@ -96,8 +91,7 @@ def get_measure_config():
 
 def density(fdistribu, grid):
     """Integrate f over all species and velocity dimensions -> n(x, y)."""
-    f_da = to_dask(fdistribu)
-    return da.sum(f_da, axis=(0, 3, 4)) * grid.dvx * grid.dvy
+    return da.sum(fdistribu, axis=(0, 3, 4)) * grid.dvx * grid.dvy
 
 
 def poisson_fft(n, grid):
@@ -106,7 +100,7 @@ def poisson_fft(n, grid):
     In Fourier space: -(kx^2 + ky^2) * phi_hat(k) = rho_hat(k)
     phi_hat(0,0) = 0  (gauge condition)
     """
-    rho_hat = da.fft.fft2(to_dask(n) - 1.0)
+    rho_hat = da.fft.fft2(n - 1.0)
 
     KX, KY = np.meshgrid(grid.kx, grid.ky, indexing="ij")
     k2 = KX ** 2 + KY ** 2
@@ -127,7 +121,7 @@ def electric_field_from_potential(phi, grid):
       E_hat_y(k) = -1j * ky * phi_hat(k)
     Returns array of shape (Nx, Ny, 2).
     """
-    phi_hat = da.fft.fft2(to_dask(phi))
+    phi_hat = da.fft.fft2(phi)
     KX, KY = np.meshgrid(grid.kx, grid.ky, indexing="ij")
     Ex = da.real(da.fft.ifft2(-1j * da.from_array(KX) * phi_hat))
     Ey = da.real(da.fft.ifft2(-1j * da.from_array(KY) * phi_hat))
@@ -135,7 +129,7 @@ def electric_field_from_potential(phi, grid):
 
 
 def electric_field_energy(Efield, grid):
-    return 0.5 * da.sum(to_dask(Efield) ** 2) * grid.dV_2D
+    return 0.5 * da.sum(Efield ** 2) * grid.dV_2D
 
 
 def measure(cfg, f, Efield, it, t_actual):
@@ -144,24 +138,31 @@ def measure(cfg, f, Efield, it, t_actual):
     data_dir.mkdir(parents=True, exist_ok=True)
     diag_file_path = data_dir / "diagnostics.csv"
 
-    f_da = to_dask(f)
-    if f_da.ndim != 4:
+    if f.ndim != 4:
         raise ValueError(
             f"Padawan, the electric force is not with you -- "
-            f"f must have 4 dimensions, not {f_da.ndim}."
+            f"f must have 4 dimensions, not {f.ndim}."
         )
 
     grid  = cfg.grid
-    vx_bc = to_dask(grid.vx)[(None, None, slice(None), None)]
-    vy_bc = to_dask(grid.vy)[(None, None, None, slice(None))]
+    vx_bc = grid.vx[(None, None, slice(None), None)]
+    vy_bc = grid.vy[(None, None, None, slice(None))]
     v2    = vx_bc ** 2 + vy_bc ** 2
 
-    epot       = float(electric_field_energy(Efield, grid).compute())
-    ekin       = float((0.5 * da.sum(f_da * v2) * grid.dV_4D).compute())
-    l2norm_sq  = float((da.sum(f_da ** 2) * grid.dV_4D).compute())
-    mass       = float((da.sum(f_da) * grid.dV_4D).compute())
-    momentum_x = float((da.sum(f_da * vx_bc) * grid.dV_4D).compute())
-    momentum_y = float((da.sum(f_da * vy_bc) * grid.dV_4D).compute())
+    epot       = electric_field_energy(Efield, grid)
+    ekin       = 0.5 * da.sum(f * v2) * grid.dV_4D
+    l2norm_sq  = da.sum(f ** 2) * grid.dV_4D
+    mass       = da.sum(f) * grid.dV_4D
+    momentum_x = da.sum(f * vx_bc) * grid.dV_4D
+    momentum_y = da.sum(f * vy_bc) * grid.dV_4D
+
+    client = get_client()
+    futures = client.compute([
+        epot, ekin, l2norm_sq, mass, momentum_x, momentum_y
+    ])
+    epot, ekin, l2norm_sq, mass, momentum_x, momentum_y = map(
+        float, deisa.client.gather(futures)
+    )
 
     data = {
         "iter":       it,
@@ -191,35 +192,31 @@ def measure(cfg, f, Efield, it, t_actual):
 
 deisa = Deisa()
 
-
-@deisa.register("fdistribu")
-def compute_diagnostics(fdistribu_chunks):
-    client = get_client()
-    coords = client.gather(client.get_dataset("coords"))
+@deisa.register("fdistribu", "absolute_time", "MeshX", "MeshY", "MeshVx", "MeshVy")
+def compute_diagnostics(fdistribu, time, mx, my, mvx, mvy):
 
     if _MEASURE_CFG is None:
         init_measure_config(
-            x  = np.array(coords['MeshX']),
-            y  = np.array(coords['MeshY']),
-            vx = np.array(coords['MeshVx']),
-            vy = np.array(coords['MeshVy']),
+            x  = mx[0],
+            y  = my[0],
+            vx = mvx[0],
+            vy = mvy[0],
         )
 
-    fdistribu = np.array(fdistribu_chunks[0])  # (Nsp, Nx, Ny, Nvx, Nvy)
-    t_actual  = float(np.array(coords['absolute_time'])[0])
-    timestep  = int(fdistribu_chunks[0].t)
+    t_actual  = float(time[0][0])
+    timestep  = int(fdistribu[0].t)
 
     cfg = get_measure_config()
 
-    n      = density(fdistribu, cfg.grid)
+    n      = density(fdistribu[0], cfg.grid)
     phi    = poisson_fft(n, cfg.grid)
     Efield = electric_field_from_potential(phi, cfg.grid)
 
-    Nsp = fdistribu.shape[0]
+    Nsp = fdistribu[0].shape[0]
     for isp in range(Nsp):
         data_dir = cfg.paths.data_dir if Nsp == 1 else cfg.paths.data_dir / f"species_{isp}"
         sp_cfg = Config(paths=PathsConfig(data_dir), grid=cfg.grid)
-        measure(sp_cfg, fdistribu[isp], Efield, timestep, t_actual)
+        measure(sp_cfg, fdistribu[0][isp], Efield, timestep, t_actual)
 
 
 deisa.execute_callbacks()

--- a/src/python/diagnostics.py
+++ b/src/python/diagnostics.py
@@ -221,7 +221,7 @@ def compute_diagnostics(fdistribu, time, deltat, mx, my, mvx, mvy):
     # and republishes t_actual before the one attached to the fdistribu chunk could be used)
     # t_actual  = float(np.array(coords['absolute_time'])[0])
     timestep  = int(fdistribu[0].t)
-    t_actual = timestep * float(np.array(deltat[0]).reshape(-1)[0])
+    t_actual = timestep * float(deltat[0][0].compute())
 
     cfg = get_measure_config()
 

--- a/toolchains/cpu.spack.mini_app_io_env/mini-app-io-env.yaml
+++ b/toolchains/cpu.spack.mini_app_io_env/mini-app-io-env.yaml
@@ -33,7 +33,7 @@ spack:
     - py-sympy@1.13
     - py-xarray@2024.7
     - py-bokeh
-    - py-deisa-dask@0.5
+    - py-deisa-dask@0.6.2
   specs:
   - matrix:
     - [$optional_packages]


### PR DESCRIPTION
- Send non-distributed arrays through Deisa (removes the publish_dataset calls)
- Remove casts of dask arrays to numpy arrays. This is unnecessary because dask arrays share the same API as numpy arrays, and it may even cause performance issues.