### PR TITLE
Toolchain enhancement

### DIFF
--- a/apps/compression/launch_benchmark.py
+++ b/apps/compression/launch_benchmark.py
@@ -26,8 +26,22 @@ SOURCE_GYSELA_YAML = os.path.join(SCRIPT_DIR, "params_landau_damping.yaml")
 SOURCE_PDI_YAML = os.path.join(SCRIPT_DIR, "pdi_out_diags.yaml")
 ANALYTICS_SCRIPT = os.path.join(BASE_DIR, "src", "python", "diagnostics.py")
 COMPRESSION_DIAGNOSTICS_SCRIPT = os.path.join(os.path.dirname(ANALYTICS_SCRIPT), "compression_diagnostics.py")
-ACTIVATE_SCRIPT = os.path.join(BASE_DIR, "apps", "io", "activate_deisa_spack_env.sh")
 SCHEFILE = os.path.join(BASE_DIR, "scheduler.json")
+
+
+# ------------------------------------------------------------------
+# Persee: toolchain environment.sh + personal venv are sourced directly
+# ------------------------------------------------------------------
+PERSEE_ENV_SCRIPT = None
+PERSEE_VENV_ACTIVATE = None
+
+
+def configure_persee(args):
+    """Resolve the toolchains/persee/<arch>/environment.sh and venv activate paths from args."""
+    global PERSEE_ENV_SCRIPT, PERSEE_VENV_ACTIVATE
+    PERSEE_ENV_SCRIPT = os.path.join(BASE_DIR, "toolchains", "persee", args.arch.lower(), "environment.sh")
+    venv_dir = os.path.abspath(args.venv) if args.venv else os.path.join(BASE_DIR, ".gys_env")
+    PERSEE_VENV_ACTIVATE = os.path.join(venv_dir, "bin", "activate")
 
 
 def parse_args():
@@ -75,6 +89,25 @@ def parse_args():
         action="store_true",
         help=(
             "Use online in-situ compression instead of the offline."
+        ),
+    )
+
+    parser.add_argument(
+        "--arch",
+        default="xeon",
+        choices=["xeon", "v100"],
+        help=(
+            "Persee arch/toolchain to activate: toolchains/persee/<arch>/"
+            "environment.sh. Default: xeon."
+        ),
+    )
+
+    parser.add_argument(
+        "--venv",
+        default=None,
+        help=(
+            "Path (relative or absolute) to the venv directory "
+            "to activate alongside the persee toolchain"
         ),
     )
 
@@ -224,16 +257,24 @@ def create_yaml_override(
 # ------------------------------------------------------------------
 
 def load_deisa_env():
-    """Source the spack+venv activation script and capture the resulting environment."""
-    if not os.path.exists(ACTIVATE_SCRIPT):
+    """Source a toolchain environment.sh + personal venv directly and capture the
+    resulting environment."""
+
+    if not os.path.exists(PERSEE_ENV_SCRIPT):
         raise RuntimeError(
-            f"Deisa activation script not found: {ACTIVATE_SCRIPT}\n"
-            "Ensure the spack environment and venv are set up as described "
-            "in apps/io/README.md."
+            f"Toolchain environment script not found: {PERSEE_ENV_SCRIPT}\n"
+            "Check --arch matches an existing toolchains/persee/<arch>/ "
         )
+
+    source_cmds = f'. "{PERSEE_ENV_SCRIPT}" 1>&2'
+    if os.path.isfile(PERSEE_VENV_ACTIVATE):
+        source_cmds += f' && . "{PERSEE_VENV_ACTIVATE}" 1>&2'
+    else:
+        print(f"[Warning] Personal venv not found at {PERSEE_VENV_ACTIVATE}; skipping.")
+
     result = subprocess.run(
         ["bash", "-c",
-         f'. "{ACTIVATE_SCRIPT}" && python3 -c '
+         f'{source_cmds} && python3 -c '
          '"import os,json,sys; sys.stdout.write(json.dumps(dict(os.environ)))"'],
         capture_output=True,
         text=True,
@@ -494,6 +535,7 @@ def compare_results(run_dir):
 
 def main():
     args = parse_args()
+    configure_persee(args)
 
     assert_file_exists(SOURCE_GYSELA_YAML, "base GYSELA input template")
     assert_file_exists(SOURCE_PDI_YAML, "base PDI input template")

--- a/installer.sh
+++ b/installer.sh
@@ -22,14 +22,14 @@ if [[ -z "${MACHINE}" ]]; then
   echo "Usage: $0 <MACHINE>" >&2
   echo "Example: $0 persee/xeon" >&2
   echo "Or set GYSELA_MACHINE=persee/xeon" >&2
-  echo "Toolchains: src/external/gyselalibxx/toolchains/" >&2
+  echo "Toolchains: toolchains/" >&2
   exit 1
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${REPO_ROOT}"
 
-TOOLCHAIN_DIR="${REPO_ROOT}/src/external/gyselalibxx/toolchains/${MACHINE}"
+TOOLCHAIN_DIR="${REPO_ROOT}/toolchains/${MACHINE}"
 ENV_SH="${TOOLCHAIN_DIR}/environment.sh"
 TOOLCHAIN_CMAKE="${TOOLCHAIN_DIR}/toolchain.cmake"
 

--- a/installer.sh
+++ b/installer.sh
@@ -14,7 +14,7 @@ MACHINE="${1:-${GYSELA_MACHINE:-}}"
 if [[ -z "${MACHINE}" ]]; then
   host="$(hostname -s 2>/dev/null || hostname)"
   case "${host}" in
-    persee*) MACHINE="persee/v100" ;;
+    persee*) MACHINE="persee/xeon" ;;
   esac
 fi
 

--- a/toolchains/adastra/genoa/environment.sh
+++ b/toolchains/adastra/genoa/environment.sh
@@ -18,6 +18,7 @@ export SPACK_USER_CACHE_PATH="${SPACK_USER_PREFIX}/cache"
 export PYTHONPYCACHEPREFIX=$ALL_CCFRSCRATCH/pycache
 
 module load develop "${SPACK_USER_VERSION}"
+module load llvm/20.1.6
 which spack
 spack debug report
 # Spack must work in a clean, purged environment so it can load modules without
@@ -59,7 +60,9 @@ eval -- "$(
         pdiplugin-pycall \
         python \
         hdf5 \
+        arrow \
         py-dask \
+        py-dask-ml \
         py-deisa-dask \
         py-h5py \
         py-imageio \

--- a/toolchains/adastra/genoa/environment.sh
+++ b/toolchains/adastra/genoa/environment.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]
+then
+    echo "This script must be sourced not executed."
+    echo ". $0"
+    exit 1
+fi
+
+module purge
+
+SPACK_USER_VERSION="spack-user-5.0.0"
+
+export SPACK_USER_PREFIX="/lus/work/CT5/gen2224/SHARED/gysela-mini-app-GENOA"
+export SPACK_USER_CACHE_PATH="${SPACK_USER_PREFIX}/cache"
+
+# Avoid too many temporary files in the Spack installation tree
+export PYTHONPYCACHEPREFIX=$ALL_CCFRSCRATCH/pycache
+
+module load develop "${SPACK_USER_VERSION}"
+which spack
+spack debug report
+# Spack must work in a clean, purged environment so it can load modules without
+# having to purge itself or clearing environment variables (which it does not
+# do..). When we spack env activate, the same constraint applies.
+# Use spack load instead of an environment activation as it should limit the
+# inode produced by the environment's view.
+# eval -- "$(spack env activate --prompt --sh gyselalibxx-spack-environment)"
+# unalias despacktivate
+# unset despacktivate
+# function despacktivate() {
+#     eval "$(spack env deactivate --sh)"
+# }
+
+eval -- "$(
+    spack \
+        --env "$SPACK_USER_PREFIX" \
+        load --sh \
+        cmake \
+        ddc \
+        gcc \
+        ginkgo \
+        googletest \
+        kokkos \
+        kokkos-fft \
+        kokkos-kernels \
+        kokkos-tools \
+        koliop \
+        lapack \
+        mpi \
+        ninja \
+        paraconf \
+        pdi \
+        pdiplugin-decl-hdf5 \
+        pdiplugin-decl-netcdf \
+        pdiplugin-mpi \
+        pdiplugin-set-value \
+        pdiplugin-trace \
+        pdiplugin-pycall \
+        python \
+        hdf5 \
+        py-dask \
+        py-deisa-dask \
+        py-h5py \
+        py-imageio \
+        py-matplotlib \
+        py-netcdf4 \
+        py-numpy \
+        py-scipy \
+        py-sympy \
+        py-xarray \
+        py-pyyaml
+)"
+
+# Add Kokkos Tools to the `LD_LIBRARY_PATH`
+export LD_LIBRARY_PATH="$(spack --env "$SPACK_USER_PREFIX" location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
+
+export GYSELALIBXX_OPENBLAS_ROOT="$(spack --env "$SPACK_USER_PREFIX" location -i openblas)"

--- a/toolchains/adastra/genoa/toolchain.cmake
+++ b/toolchains/adastra/genoa/toolchain.cmake
@@ -1,0 +1,11 @@
+# CMake options
+# NOTE: We are not supposed to define CMAKE_BUILD_TYPE here.
+set(CMAKE_BUILD_TYPE Release) # Debug, Release, RelWithDebInfo and MinSizeRel
+
+# Compiler options
+set(CMAKE_CXX_COMPILER g++)
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_Fortran_COMPILER gfortran)
+# We should add that too, but there is too much warnings ! -Wsuggest-override -Wctor-dtor-privacy -Wdouble-promotion -Wcast-qual -Wredundant-decls -Wswitch-default -Wold-style-cast -Wswitch-enum -Wundef
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -isystem $ENV{GYSELALIBXX_OPENBLAS_ROOT}/include")

--- a/toolchains/adastra/mi250/environment.sh
+++ b/toolchains/adastra/mi250/environment.sh
@@ -14,6 +14,8 @@ SPACK_USER_VERSION="spack-user-5.0.0"
 export SPACK_USER_PREFIX="/lus/work/CT5/gen2224/SHARED/gysela-mini-app-GENOA"
 export SPACK_USER_CACHE_PATH="${SPACK_USER_PREFIX}/cache"
 
+export SPACK_USER_CONFIG_PATH="${ALL_CCFRWORK}/gyselalibxx-spack-install-py314-genoa/configuration"
+
 # Avoid too many temporary files in the Spack installation tree
 export PYTHONPYCACHEPREFIX=$ALL_CCFRSCRATCH/pycache
 
@@ -21,17 +23,11 @@ module load develop "${SPACK_USER_VERSION}"
 module load llvm/20.1.6
 which spack
 spack debug report
-# Spack must work in a clean, purged environment so it can load modules without
-# having to purge itself or clearing environment variables (which it does not
-# do..). When we spack env activate, the same constraint applies.
-# Use spack load instead of an environment activation as it should limit the
-# inode produced by the environment's view.
-# eval -- "$(spack env activate --prompt --sh gyselalibxx-spack-environment)"
-# unalias despacktivate
-# unset despacktivate
-# function despacktivate() {
-#     eval "$(spack env deactivate --sh)"
-# }
+
+. /lus/home/softs/gaia/prod/5.0.0/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_plac/spack-1.0.1-gcc-13.2.1-3ra4/share/spack/setup-env.sh
+
+# Activate the environment in the scratch directory
+# spack env activate $SPACK_USER_PREFIX
 
 eval -- "$(
     spack \

--- a/toolchains/adastra/mi250/toolchain.cmake
+++ b/toolchains/adastra/mi250/toolchain.cmake
@@ -1,0 +1,13 @@
+# CMake options
+# NOTE: We are not supposed to define CMAKE_BUILD_TYPE here.
+set(CMAKE_BUILD_TYPE Release) # Debug, Release, RelWithDebInfo and MinSizeRel
+
+# Compiler options
+set(CMAKE_CXX_COMPILER hipcc)
+set(CMAKE_C_COMPILER amdclang)
+set(CMAKE_Fortran_COMPILER amdflang)
+set(CMAKE_CXX_EXTENSIONS OFF)
+# We should add that too, but there is too much warnings ! -Wsuggest-override -Wctor-dtor-privacy -Wdouble-promotion -Wcast-qual -Wredundant-decls -Wswitch-default -Wold-style-cast -Wswitch-enum -Wundef
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -isystem $ENV{GYSELALIBXX_OPENBLAS_ROOT}/include")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-L/opt/cray/pe/mpich/8.1.30/gtl/lib -lmpi_gtl_hsa")

--- a/toolchains/persee/v100/environment.sh
+++ b/toolchains/persee/v100/environment.sh
@@ -33,3 +33,5 @@ export OMP_NUM_THREADS=8
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`
 export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
+
+export PYTHONPATH=/data/gyselarunner/gysela-io-env-deisa-cuda/.spack-env/view/lib/python3.13/site-packages:${PYTHONPATH:-}

--- a/toolchains/persee/v100/environment.sh
+++ b/toolchains/persee/v100/environment.sh
@@ -19,7 +19,7 @@ fi
 # The hdf5 package is injecting the environment view `lib` path to `LD_LIBRARY_PATH`
 # which causes spurious segfaults for system executables, we manually remove it.
 LD_LIBRARY_PATH_TMP="$LD_LIBRARY_PATH"
-spack env activate /data/gyselarunner/gysela-io-env-deisa/
+spack env activate /data/gyselarunner/gysela-io-env-deisa-cuda/
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH_TMP"
 unset LD_LIBRARY_PATH_TMP
 
@@ -29,7 +29,7 @@ unset LD_PRELOAD
 
 export OMP_PROC_BIND=spread
 export OMP_PLACES=threads
-export OMP_NUM_THREADS=16
+export OMP_NUM_THREADS=8
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`
 export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"

--- a/toolchains/persee/v100/toolchain.cmake
+++ b/toolchains/persee/v100/toolchain.cmake
@@ -1,0 +1,22 @@
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../../src/external/gyselalibxx/toolchains/common_toolchains/importable_defaults.cmake)
+
+# CMake options
+set(CMAKE_BUILD_TYPE Release)
+
+# Compiler options
+set(CMAKE_CXX_COMPILER nvcc_wrapper)
+set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
+# The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
+# Using CUDA 12.9 triggers a spurious warning when compiling for Nvidia Volta architectures. We then disable it.
+set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra -Wno-deprecated-gpu-targets")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
+
+# Gyselalibxx options
+set(GYSELALIBXX_DEFAULT_CXX_FLAGS "" CACHE STRING "Default flags for C++ specific to Gyselalib++" FORCE)
+
+# Activate/deactivate parts of the code
+if (DEFINED ENV{DDC_BUILD_TESTING})
+    set(DDC_BUILD_TESTS $ENV{DDC_BUILD_TESTING})
+endif()
+set(ACTIVATE_RESTART_TESTS OFF)

--- a/toolchains/persee/xeon/environment.sh
+++ b/toolchains/persee/xeon/environment.sh
@@ -33,3 +33,5 @@ export OMP_NUM_THREADS=16
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`
 export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
+
+export PYTHONPATH=/data/gyselarunner/gysela-io-env-deisa/.spack-env/view/lib/python3.13/site-packages:${PYTHONPATH:-}

--- a/toolchains/persee/xeon/toolchain.cmake
+++ b/toolchains/persee/xeon/toolchain.cmake
@@ -1,5 +1,5 @@
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../common_toolchains/importable_defaults.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../../src/external/gyselalibxx/toolchains/common_toolchains/importable_defaults.cmake)
 
 # CMake options
 set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
- Adds toolchain.cmake and environment.sh for persee (v100 and xeon) and adastra (Genoa and mi250)
- uses the environment.sh files as activating script in launch_benchmark