### PR TITLE
Solve Cmake link errors, refactor gys_compress.cpp splinebuilders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ find_package(GTest "1.12" QUIET)
 ## Look for a pre-installed paraconf
 find_package(paraconf REQUIRED COMPONENTS C)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+add_link_options(-no-pie)
+
 ###############################################################################################
 #                           List of options for Gyselalib++ library
 ###############################################################################################

--- a/apps/compression/CMakeLists.txt
+++ b/apps/compression/CMakeLists.txt
@@ -13,12 +13,12 @@ target_link_libraries(gys_compress
         PDI::PDI_C
         paraconf::paraconf
         MPI::MPI_CXX
-        gslx::initialisation_xyvxvy
-        gslx::vlasov_xyvxvy
-        gslx::poisson_xy
+        gslx::initialisation_xyvxvy_double
+        gslx::vlasov_xyvxvy_double
+        gslx::poisson_xy_double
         gslx::advection
         gslx::speciesinfo
-        gslx::time_integration_xyvxvy
+        gslx::time_integration_xyvxvy_double
         gslx::io
         gslx::utils
 )

--- a/apps/compression/gys_compress.cpp
+++ b/apps/compression/gys_compress.cpp
@@ -266,10 +266,10 @@ int main(int argc, char **argv) {
   IdxRangeVxVyXY idxrange_vxvyxy_v2Dsplit(idxrange_spvxvyxy_v2Dsplit);
   IdxRangeXYVxVy idxrange_xyvxvy_x2Dsplit(idxrange_spxyvxvy_x2Dsplit);
 
-  SplineXBuilder const builder_x(idxrange_x);
-  SplineYBuilder const builder_y(idxrange_y);
-  SplineVxBuilder const builder_vx(idxrange_vx);
-  SplineVyBuilder const builder_vy(idxrange_vy);
+  SplineInterpolatorX const interpolator_x(idxrange_x);
+  SplineInterpolatorY const interpolator_y(idxrange_y);
+  SplineInterpolatorVx const interpolator_vx(idxrange_vx);
+  SplineInterpolatorVy const interpolator_vy(idxrange_vy);
 
   IdxRangeSpVxVy idxrange_spvxvy_local(idxrange_spxyvxvy_x2Dsplit);
 
@@ -358,47 +358,23 @@ int main(int argc, char **argv) {
   int const nbstep_diag =
       static_cast<int>(PCpp_int(configs.conf_gyselax, ".Output.nbiter_diag"));
 
-  // Create spline evaluator
-  ddc::PeriodicExtrapolationRule<X> bv_x_min;
-  ddc::PeriodicExtrapolationRule<X> bv_x_max;
-  SplineXEvaluator const spline_x_evaluator(bv_x_min, bv_x_max);
-
-  ddc::PeriodicExtrapolationRule<Y> bv_y_min;
-  ddc::PeriodicExtrapolationRule<Y> bv_y_max;
-  SplineYEvaluator const spline_y_evaluator(bv_y_min, bv_y_max);
-
-  ddc::ConstantExtrapolationRule<Vx> bv_vx_min(
-      ddc::coordinate(idxrange_vx.front()));
-  ddc::ConstantExtrapolationRule<Vx> bv_vx_max(
-      ddc::coordinate(idxrange_vx.back()));
-  SplineVxEvaluator const spline_vx_evaluator(bv_vx_min, bv_vx_max);
-
-  ddc::ConstantExtrapolationRule<Vy> bv_vy_min(
-      ddc::coordinate(idxrange_vy.front()));
-  ddc::ConstantExtrapolationRule<Vy> bv_vy_max(
-      ddc::coordinate(idxrange_vy.back()));
-  SplineVyEvaluator const spline_vy_evaluator(bv_vy_min, bv_vy_max);
 
   // Create advection operator
-  BslAdvectionSpatial<GeometryVxVyXY, GridX, SplineXBuilder,
-                      SplineXEvaluator> const advection_x(builder_x,
-                                                          spline_x_evaluator);
-  BslAdvectionSpatial<GeometryVxVyXY, GridY, SplineYBuilder,
-                      SplineYEvaluator> const advection_y(builder_y,
-                                                          spline_y_evaluator);
-  BslAdvectionVelocity<GeometryXYVxVy, GridVx, SplineVxBuilder,
-                       SplineVxEvaluator> const
-      advection_vx(builder_vx, spline_vx_evaluator);
-  BslAdvectionVelocity<GeometryXYVxVy, GridVy, SplineVyBuilder,
-                       SplineVyEvaluator> const
-      advection_vy(builder_vy, spline_vy_evaluator);
+  BslAdvectionSpatial<GeometryVxVyXY, SplineInterpolatorX, Real> const
+      advection_x(interpolator_x);
+  BslAdvectionSpatial<GeometryVxVyXY, SplineInterpolatorY, Real> const
+      advection_y(interpolator_y);
+  BslAdvectionVelocity<GeometryXYVxVy, SplineInterpolatorVx, Real> const
+      advection_vx(interpolator_vx);
+  BslAdvectionVelocity<GeometryXYVxVy, SplineInterpolatorVy, Real> const
+      advection_vy(interpolator_vy);
 
   MpiSplitVlasovSolver const vlasov(advection_x, advection_y, advection_vx,
                                     advection_vy, transpose);
 
   DFieldMemVxVy const quadrature_coeffs(
       neumann_spline_quadrature_coefficients<Kokkos::DefaultExecutionSpace>(
-          idxrange_vxvy, builder_vx, builder_vy));
+          idxrange_vxvy, interpolator_vx.get_builder(), interpolator_vy.get_builder()));
   DFieldMemVxVy local_quadrature_coeffs(idxrange_vxvy_v2Dsplit);
   ddc::parallel_deepcopy(get_field(local_quadrature_coeffs),
                          quadrature_coeffs[idxrange_vxvy_v2Dsplit]);

--- a/apps/compression/launch_benchmark.py
+++ b/apps/compression/launch_benchmark.py
@@ -248,7 +248,12 @@ def start_dask(deisa_env, n_workers=1):
         os.remove(SCHEFILE)
 
     sch_proc = subprocess.Popen(
-        ["dask-scheduler", f"--scheduler-file={SCHEFILE}"],
+        [
+            "dask-scheduler",
+            f"--scheduler-file={SCHEFILE}",
+            "--port", "0",
+            "--dashboard-address", ":0",
+        ],
         env=deisa_env,
     )
 

--- a/apps/io/CMakeLists.txt
+++ b/apps/io/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(gys_io
     PUBLIC
         mini_app_io_lib
         DDC::core
+        DDC::pdi
         PDI::PDI_C
         paraconf::paraconf
         MPI::MPI_CXX


### PR DESCRIPTION
- solve Cmake link errors
- use new Splinebuilder API (from gyselalibxx update)
- use port = 0 for the dask scheduler to force the os to use an ephemeral port instead of a fixed one (when two people launch the dask scheduler on the same machine, for example persee, the address can only be used by one of the two)