### PR TITLE
Solve typo in mi250 environement

### DIFF
--- a/toolchains/adastra/mi250/environment.sh
+++ b/toolchains/adastra/mi250/environment.sh
@@ -62,7 +62,7 @@ eval -- "$(
         py-dask-ml \
         py-deisa-dask \
         py-deisa-ray \
-        py-iops-benchopt \
+        py-iops-benchmark \
         py-h5py \
         py-imageio \
         py-matplotlib \


### PR DESCRIPTION
Use `py-iops-benchmark` in the spack load command.