### PR TITLE
60 reduced diagnostics

### DIFF
--- a/apps/compression/launch_benchmark.py
+++ b/apps/compression/launch_benchmark.py
@@ -191,6 +191,20 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--diag-mode",
+        type=int,
+        choices=[0, 1, 2],
+        default=0,
+        help=(
+            "In-situ diagnostics mode (sets GYS_DIAG_MODE for every branch): "
+            "0 = full fdistribu through deisa, FFT-based Poisson solve (default); "
+            "1 = local per-rank reduction sent through the deisa bridge; "
+            "2 = local per-rank reduction written to per-rank csv, deisa bypassed "
+            "-- run src/python/finalize_reduced_diagnostics.py <branch_dir> afterwards to produce diagnostics.csv."
+        ),
+    )
+
+    parser.add_argument(
         "--arch",
         default="GENOA" if resolve_site() == "adastra" else "xeon",
         help=(
@@ -556,7 +570,7 @@ def write_compression_manifest(run_dir, compression_events):
     print(f"\nCompression event manifest written to: {manifest_path}")
 
 
-def run_baseline(run_dir, run_pdi_yaml, iter_total, n_workers=1):
+def run_baseline(run_dir, run_pdi_yaml, iter_total, n_workers=1, diag_mode=0):
     dir_baseline = os.path.join(run_dir, "branch_baseline")
     yaml_baseline = os.path.join(run_dir, "config_baseline.yaml")
 
@@ -575,12 +589,13 @@ def run_baseline(run_dir, run_pdi_yaml, iter_total, n_workers=1):
         pdi_yaml=run_pdi_yaml,
         work_dir=dir_baseline,
         n_workers=n_workers,
+        extra_env={"GYS_DIAG_MODE": diag_mode},
     )
 
     return dir_baseline
 
 
-def run_offline_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, mesh_kwargs=None, n_workers=1):
+def run_offline_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, mesh_kwargs=None, n_workers=1, diag_mode=0):
     dir_offline = os.path.join(run_dir, "branch_offline_compressed")
     yaml_offline = os.path.join(run_dir, "config_offline_compressed.yaml")
 
@@ -595,7 +610,9 @@ def run_offline_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression
         compression_mode=2,
     )
 
-    extra_env = {"COMPRESSION_MESH_KWARGS": json.dumps(mesh_kwargs)} if mesh_kwargs else None
+    extra_env = {"GYS_DIAG_MODE": diag_mode}
+    if mesh_kwargs:
+        extra_env["COMPRESSION_MESH_KWARGS"] = json.dumps(mesh_kwargs)
 
     run_sim_with_diagnostics(
         branch_name="Offline compressed",
@@ -620,7 +637,7 @@ def _collect_offline_compression_events(work_dir):
         return [dict(row) for row in csv.DictReader(fh)]
 
 
-def run_online_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, n_workers=1):
+def run_online_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_period, n_workers=1, diag_mode=0):
     dir_online = os.path.join(run_dir, "branch_online_compressed")
     yaml_online = os.path.join(run_dir, "config_online_compressed.yaml")
 
@@ -641,6 +658,7 @@ def run_online_compressed_branch(run_dir, run_pdi_yaml, iter_total, compression_
         pdi_yaml=run_pdi_yaml,
         work_dir=dir_online,
         n_workers=n_workers,
+        extra_env={"GYS_DIAG_MODE": diag_mode},
     )
 
     events = _collect_online_compression_events(dir_online)
@@ -734,6 +752,7 @@ def submit_batch_and_wait(args):
         forwarded.append("--keep-pdi-copy")
     if args.online:
         forwarded.append("--online")
+    forwarded += ["--diag-mode", str(args.diag_mode)]
     if args.dask_workers is not None:
         forwarded += ["--dask-workers", str(args.dask_workers)]
     forwarded += ["--nprocs", str(args.nprocs)]
@@ -822,6 +841,7 @@ def run_pipeline(args):
             run_pdi_yaml=run_pdi_yaml,
             iter_total=iter_total,
             n_workers=n_workers,
+            diag_mode=args.diag_mode,
         )
 
     if args.online:
@@ -831,6 +851,7 @@ def run_pipeline(args):
             iter_total=iter_total,
             compression_period=compression_period,
             n_workers=n_workers,
+            diag_mode=args.diag_mode,
         )
     else:
         run_offline_compressed_branch(
@@ -840,6 +861,7 @@ def run_pipeline(args):
             compression_period=compression_period,
             mesh_kwargs=mesh_kwargs,
             n_workers=n_workers,
+            diag_mode=args.diag_mode,
         )
 
     if not args.keep_pdi_copy:

--- a/apps/compression/pdi_out_diags.yaml
+++ b/apps/compression/pdi_out_diags.yaml
@@ -78,14 +78,18 @@ plugins:
       Init:
         with: {}
         exec: |
+          import os
           import time
           import numpy as np
           from mpi4py import MPI
           from deisa.dask import Bridge
           import compression_diagnostics
+          import reduced_diagnostics
           import pdi
           comm = MPI.COMM_WORLD
           rank = comm.Get_rank()
+          # 0 = full f through deisa, 1 = reduced through deisa, 2 = reduced to csv (deisa bypassed)
+          diag_mode = int(os.environ.get("GYS_DIAG_MODE", "0"))
       InitBridge:
         with: { global_fdistribu_extents: $global_fdistribu_extents,
                 local_fdistribu_extents: $local_fdistribu_extents,
@@ -103,6 +107,7 @@ plugins:
           global_shape = tuple(int(x) for x in global_fdistribu_extents)
           local_shape  = tuple(int(x) for x in local_fdistribu_extents)
           chunk_pos    = tuple((local_fdistribu_starts // local_fdistribu_extents).astype(int).tolist())
+          nsp_global = global_shape[0]
           arrays_metadata = {
               'fdistribu': {
                   'global_shape':   global_shape,
@@ -113,6 +118,11 @@ plugins:
                   'global_shape':   global_shape,
                   'chunk_shape':    local_shape,
                   'chunk_position': chunk_pos,
+              },
+              'fdistribu_reduced': {
+                  'global_shape':   (comm.Get_size(), nsp_global, reduced_diagnostics.N_PARTIALS),
+                  'chunk_shape':    (1, nsp_global, reduced_diagnostics.N_PARTIALS),
+                  'chunk_position': (rank, 0, 0),
               },
           }
 
@@ -136,6 +146,7 @@ plugins:
             arrays_metadata = dict(arrays_metadata, **non_dist_arrays)
 
           bridge = Bridge(comm, arrays_metadata)
+          t1 = time.time()
       iteration:
         with:
           fdistribu: $fdistribu
@@ -143,7 +154,6 @@ plugins:
           t: $absolute_time
           deltat: $deltat
           iter_offset: $iter_offset
-          deltat: $deltat
           nbstep_diag: $nbstep_diag
           nb_step_compression: $nb_step_compression
           compression_mode: $compression_mode
@@ -153,20 +163,15 @@ plugins:
           MeshVy: $MeshVy
           local_fdistribu_starts: $local_fdistribu_starts
         exec: |
+          t0 = time.time()
           timestep = int(it) + int(iter_offset)
+          if rank == 0:
+            print(f"C++ iteration time : {t0 - t1}", flush=True)
 
           if int(nb_step_compression) > 0 and timestep > 0 and timestep % int(nb_step_compression) == 0:
             # Online Compression
             if int(compression_mode) == 1:
-              starts = np.asarray(local_fdistribu_starts).astype(int)
-              nx_l, ny_l, nvx_l, nvy_l = fdistribu.shape[1:]
-              local_bounds = (
-                float(MeshX[starts[1]]), float(MeshX[starts[1] + nx_l - 1]),
-                float(MeshY[starts[2]]), float(MeshY[starts[2] + ny_l - 1]),
-                float(MeshVx[starts[3]]), float(MeshVx[starts[3] + nvx_l - 1]),
-                float(MeshVy[starts[4]]), float(MeshVy[starts[4] + nvy_l - 1]),
-              )
-              compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank(), local_bounds=local_bounds)
+              compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank())
             # Offline Compression
             elif int(compression_mode) == 2:
               bridge.send("fdistribu_offline", fdistribu, timestep)
@@ -186,8 +191,18 @@ plugins:
               pdi.event("read_compressed_fdistribu")
 
           if timestep % int(nbstep_diag) == 0:
-            bridge.send("fdistribu", fdistribu, timestep)
-            if rank == 0:
+            if diag_mode == 1:
+              # Reduced diagnostics: local partial sums, finished by the fdistribu_reduced callback
+              partial = reduced_diagnostics.local_reduce(fdistribu, local_fdistribu_starts, MeshVx, MeshVy, nsp_global)
+              bridge.send("fdistribu_reduced", partial[None], timestep)
+            elif diag_mode == 2:
+              # Reduced diagnostics: local partial sums to csv, finished post hoc (deisa bypassed / post-hoc finalization)
+              partial = reduced_diagnostics.local_reduce(fdistribu, local_fdistribu_starts, MeshVx, MeshVy, nsp_global)
+              reduced_diagnostics.append_partial_csv(partial, timestep, float(t), rank)
+            else:
+              bridge.send("fdistribu", fdistribu, timestep)
+
+            if diag_mode != 2 and rank == 0:
               bridge.send("absolute_time", np.array([float(t)]), timestep)
               bridge.send("deltat", np.array([float(deltat)]), timestep)
               bridge.send("MeshX",  np.array(MeshX),  timestep)
@@ -196,7 +211,8 @@ plugins:
               bridge.send("MeshVy", np.array(MeshVy), timestep)
           if timestep % 10 == 0:
             if rank == 0:
-              print(f"--------------------------timestep: {timestep}")
+              print(f"--------------------------timestep: {timestep}", flush=True)
+          t1 = time.time()
       last_iteration:
         with:
           fdistribu: $fdistribu
@@ -204,7 +220,6 @@ plugins:
           t: $absolute_time
           deltat: $deltat
           iter_offset: $iter_offset
-          deltat: $deltat
           nb_step_compression: $nb_step_compression
           compression_mode: $compression_mode
           MeshX: $MeshX
@@ -218,15 +233,7 @@ plugins:
           if int(nb_step_compression) > 0 and timestep > 0 and timestep % int(nb_step_compression) == 0:
             # Online Compression
             if int(compression_mode) == 1:
-              starts = np.asarray(local_fdistribu_starts).astype(int)
-              nx_l, ny_l, nvx_l, nvy_l = fdistribu.shape[1:]
-              local_bounds = (
-                float(MeshX[starts[1]]), float(MeshX[starts[1] + nx_l - 1]),
-                float(MeshY[starts[2]]), float(MeshY[starts[2] + ny_l - 1]),
-                float(MeshVx[starts[3]]), float(MeshVx[starts[3] + nvx_l - 1]),
-                float(MeshVy[starts[4]]), float(MeshVy[starts[4] + nvy_l - 1]),
-              )
-              compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank(), local_bounds=local_bounds)
+              compression_diagnostics.apply_online_compression(fdistribu, timestep, comm.Get_rank())
             # Offline Compression
             elif int(compression_mode) == 2:
               bridge.send("fdistribu_offline", fdistribu, timestep)
@@ -245,8 +252,18 @@ plugins:
                   time.sleep(0.05)
               pdi.event("read_compressed_fdistribu")
 
-          bridge.send("fdistribu", fdistribu, timestep)
-          if rank == 0:
+          if diag_mode == 1:
+            # Reduced diagnostics: local partial sums, finished by the fdistribu_reduced callback
+            partial = reduced_diagnostics.local_reduce(fdistribu, local_fdistribu_starts, MeshVx, MeshVy, nsp_global)
+            bridge.send("fdistribu_reduced", partial[None], timestep)
+          elif diag_mode == 2:
+            # Reduced diagnostics: local partial sums to csv, finished post hoc (deisa bypassed)
+            partial = reduced_diagnostics.local_reduce(fdistribu, local_fdistribu_starts, MeshVx, MeshVy, nsp_global)
+            reduced_diagnostics.append_partial_csv(partial, timestep, float(t), rank)
+          else:
+            bridge.send("fdistribu", fdistribu, timestep)
+
+          if diag_mode != 2 and rank == 0:
             bridge.send("absolute_time", np.array([float(t)]), timestep)
             bridge.send("deltat", np.array([float(deltat)]), timestep)
             bridge.send("MeshX",  np.array(MeshX),  timestep)
@@ -320,3 +337,4 @@ plugins:
             start: [ '$local_fdistribu_starts[0]', '$local_fdistribu_starts[1]', '$local_fdistribu_starts[2]', '$local_fdistribu_starts[3]', '$local_fdistribu_starts[4]' ]
         electrostatic_potential: ~
   #trace: ~
+

--- a/src/python/diagnostics.py
+++ b/src/python/diagnostics.py
@@ -1,7 +1,6 @@
 """In-situ diagnostics: conserved-variable calculations and deisa analytics callback."""
 
 import csv
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -11,14 +10,9 @@ from deisa.dask import Deisa
 from distributed import get_client
 
 import compression_diagnostics
+import reduced_diagnostics
 
 _MEASURE_CFG = None
-
-# Wall-clock reference point for this process, taken as soon as diagnostics.py
-# starts (i.e. essentially when the simulation launches). Elapsed time from
-# here covers simulation, compression, and diagnostics running concurrently.
-_START_TIME = time.monotonic()
-
 
 @dataclass
 class PathsConfig:
@@ -177,7 +171,6 @@ def measure(cfg, f, Efield, it, t_actual):
     data = {
         "iter":       it,
         "time":       float(t_actual),
-        "cpu_time":   time.monotonic() - _START_TIME,
         "ekin":       ekin,
         "epot":       epot,
         "etot":       ekin + epot,
@@ -212,6 +205,19 @@ def compute_offline_compression(fdistribu_chunks):
     compression_diagnostics.run_offline_compression_on_global_array(fdistribu_global, timestep)
 
     deisa.set("fdistribu_offline_done", True, timestep=timestep)
+
+
+@deisa.register("fdistribu_reduced", "deltat", "MeshX", "MeshY", "MeshVx", "MeshVy")
+def compute_reduced_diagnostics(reduced, deltat, mx, my, mvx, mvy):
+    timestep = int(reduced[0].t)
+    t_actual = timestep * float(deltat[0][0].compute())
+
+    dV_4D = (GridConfig.spacing(mx[0]) * GridConfig.spacing(my[0])
+              * GridConfig.spacing(mvx[0]) * GridConfig.spacing(mvy[0]))
+
+    partials = np.asarray(reduced[0].sum(axis=0))  # (n_ranks, Nsp, 5) -> (Nsp, 5)
+
+    reduced_diagnostics.write_diagnostics_rows(partials, dV_4D, timestep, t_actual, _INITIALIZED_DIAG_FILES)
 
 
 @deisa.register("fdistribu", "absolute_time", "deltat", "MeshX", "MeshY", "MeshVx", "MeshVy")
@@ -260,3 +266,4 @@ def _sort_diagnostics_files():
 
 
 _sort_diagnostics_files()
+

--- a/src/python/finalize_reduced_diagnostics.py
+++ b/src/python/finalize_reduced_diagnostics.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Post hoc finalisation of the per-rank partial diagnostics written with GYS_DIAG_MODE=2."""
+
+import argparse
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+import reduced_diagnostics
+
+
+def read_dV_4D(work_dir):
+    """Read the mesh from GYSELALIBXX_initstate.h5 and return dx * dy * dvx * dvy."""
+    with h5py.File(Path(work_dir) / "GYSELALIBXX_initstate.h5", "r") as fh5:
+        return float(np.prod([fh5[m][1] - fh5[m][0] for m in ("MeshX", "MeshY", "MeshVx", "MeshVy")]))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Finish the reduced diagnostics from per-rank partial csv files.")
+    parser.add_argument("work_dir", help="Branch directory containing partial_diagnostics_rank*.csv")
+    args = parser.parse_args()
+
+    work_dir = Path(args.work_dir)
+    partial_files = sorted(work_dir.glob("partial_diagnostics_rank*.csv"))
+    if not partial_files:
+        raise RuntimeError(f"No partial_diagnostics_rank*.csv found in {work_dir}")
+
+    # summed[(iter, time)][species] -> partial sums accumulated over ranks
+    summed = defaultdict(lambda: defaultdict(lambda: np.zeros(reduced_diagnostics.N_PARTIALS)))
+    for path in partial_files:
+        with open(path, newline="") as fh:
+            for row in csv.DictReader(fh):
+                key = (int(row["iter"]), float(row["time"]))
+                summed[key][int(row["species"])] += np.array(
+                    [float(row[name]) for name in reduced_diagnostics.PARTIAL_FIELDS]
+                )
+
+    dV_4D = read_dV_4D(work_dir)
+    initialized_paths = set()
+    for it, t_actual in sorted(summed):
+        by_species = summed[(it, t_actual)]
+        partials = np.stack([by_species[isp] for isp in sorted(by_species)])
+        reduced_diagnostics.write_diagnostics_rows(partials, dV_4D, it, t_actual, initialized_paths, work_dir)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/python/reduced_diagnostics.py
+++ b/src/python/reduced_diagnostics.py
@@ -1,0 +1,93 @@
+"""Reduced diagnostics: rank-local partial sums finished either by a deisa callback or post hoc."""
+
+from pathlib import Path
+import csv
+
+import numpy as np
+
+PARTIAL_FIELDS = ["mass", "ekin", "l2norm_sq", "momentum_x", "momentum_y"]
+N_PARTIALS = len(PARTIAL_FIELDS)
+
+
+def local_reduce(f_local, starts, mesh_vx, mesh_vy, nsp_global):
+    """Reduce the local f chunk over (x, y, vx, vy) -> partial sums of shape (Nsp, 5)."""
+    f = np.asarray(f_local)
+    s0, svx, svy = int(starts[0]), int(starts[3]), int(starts[4])
+    vx = np.asarray(mesh_vx)[svx: svx + f.shape[3]][None, None, None, :, None]
+    vy = np.asarray(mesh_vy)[svy: svy + f.shape[4]][None, None, None, None, :]
+    axes = (1, 2, 3, 4)
+
+    partial = np.zeros((int(nsp_global), N_PARTIALS))
+    sp = slice(s0, s0 + f.shape[0])
+    partial[sp, 0] = f.sum(axis=axes)
+    partial[sp, 1] = 0.5 * (f * (vx ** 2 + vy ** 2)).sum(axis=axes)
+    partial[sp, 2] = (f ** 2).sum(axis=axes)
+    partial[sp, 3] = (f * vx).sum(axis=axes)
+    partial[sp, 4] = (f * vy).sum(axis=axes)
+    return partial
+
+
+def append_partial_csv(partial, it, t_actual, rank, data_dir="."):
+    """Append the rank-local partial sums to partial_diagnostics_rank<rank>.csv.
+
+    Called synchronously and in iteration order from within a single MPI rank's
+    pycall event, so (unlike write_diagnostics_rows below) there's no risk of an
+    out-of-order write here -- a plain it==0 reset is safe.
+    """
+    data_dir = Path(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    path = data_dir / f"partial_diagnostics_rank{rank:03d}.csv"
+
+    reset = it == 0
+    write_header = reset or not path.is_file()
+    with open(path, mode="w" if reset else "a", newline="") as fh:
+        writer = csv.writer(fh)
+        if write_header:
+            writer.writerow(["iter", "time", "species"] + PARTIAL_FIELDS)
+        for isp in range(partial.shape[0]):
+            writer.writerow([it, float(t_actual), isp] + [float(v) for v in partial[isp]])
+
+
+def finalize_row(partial_sp, dV_4D, it, t_actual):
+    """Scale summed partials by dV_4D into a diagnostics.csv row.
+
+    epot/etot need the field solve, which isn't possible on scattered data -> nan.
+    """
+    mass, ekin, l2norm_sq, momentum_x, momentum_y = (float(v) * dV_4D for v in partial_sp)
+    epot = float("nan")
+    return {
+        "iter":       it,
+        "time":       float(t_actual),
+        "ekin":       ekin,
+        "epot":       epot,
+        "etot":       ekin + epot,
+        "l2norm":     float(np.sqrt(l2norm_sq)),
+        "mass":       mass,
+        "momentum":   float(np.hypot(momentum_x, momentum_y)),
+        "momentum_x": momentum_x,
+        "momentum_y": momentum_y,
+    }
+
+
+def write_diagnostics_rows(partials, dV_4D, it, t_actual, initialized_paths, data_dir="."):
+    """Append one diagnostics.csv row per species, laid out as in diagnostics.measure.
+
+    initialized_paths is a set the caller owns and passes on every call (e.g.
+    diagnostics.py's _INITIALIZED_DIAG_FILES, or a fresh set kept alive across
+    a post-hoc loop) - a path resets (mode 'w') only the first time it's seen.
+    """
+    nsp = partials.shape[0]
+    for isp in range(nsp):
+        sp_dir = Path(data_dir) if nsp == 1 else Path(data_dir) / f"species_{isp}"
+        sp_dir.mkdir(parents=True, exist_ok=True)
+        path = sp_dir / "diagnostics.csv"
+
+        data = finalize_row(partials[isp], dV_4D, it, t_actual)
+        reset = path not in initialized_paths
+        initialized_paths.add(path)
+        write_header = reset or not path.is_file()
+        with open(path, mode="w" if reset else "a", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=data.keys())
+            if write_header:
+                writer.writeheader()
+            writer.writerow(data)

--- a/toolchains/adastra/genoa/environment.sh
+++ b/toolchains/adastra/genoa/environment.sh
@@ -37,9 +37,9 @@ eval -- "$(
     spack \
         --env "$SPACK_USER_PREFIX" \
         load --sh \
-        cmake \
+        cmake/fj24njq \
         ddc \
-        gcc \
+        gcc/qqhhni4 \
         ginkgo \
         gmgpolar \
         googletest \


### PR DESCRIPTION
Reduced diagnostics: local reduction instead of global FFT

Adds a --diag-mode flag to skip the full-field FFT diagnostics:

0 (default): unchanged, full fdistribu through deisa.
1: local per-rank reduction (mass/ekin/l2norm/momentum) sent through the deisa bridge.
2: same reduction, written to per-rank csv instead, deisa bypassed, finalized post hoc. The finalization script isn't launched during the` launch_benchmark.py` execution

epot/etot are nan in modes 1/2 — not computable from scattered data. diagnostics.csv schema is otherwise unchanged.

Files: pdi_out_diags.yaml, diagnostics.py, reduced_diagnostics.py, finalize_reduced_diagnostics.py, launch_benchmark.py.