### PR TITLE
Remove Gyselalib++ GYSELALIBXX_INCLUDE_TESTING_DEPENDENCIES option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ add_link_options(-no-pie)
 set(GYSELALIBXX_BUILD_TESTING OFF)
 set(GYSELALIBXX_BUILD_SIMULATIONS OFF)
 set(GYSELALIBXX_BUILD_DOCUMENTATION OFF)
-set(GYSELALIBXX_INCLUDE_TESTING_DEPENDENCIES ON)
 
 
 ###############################################################################################


### PR DESCRIPTION
This was removed in https://github.com/gyselax/gyselalibxx/commit/9d3ce079308cf69fe3322ee9300da6adebb99ef0