### PR TITLE
Remove remaining find_package call, for now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,6 @@
 cmake_minimum_required(VERSION 3.25)
 project(gysela-mini-app_io C CXX)
 
-## Look for a pre-installed paraconf
-find_package(paraconf REQUIRED COMPONENTS C)
-
 ###############################################################################################
 #                           List of options for Gyselalib++ library
 ###############################################################################################


### PR DESCRIPTION
This `find_package` is actually ok but it is only the dependency (we also have MPI, DDC, PDI...) that we find with `find_package`. I suggest to remove it and do a proper pass on dependencies in a following PR.