### PR TITLE
Remove ENVIRONMENT property on targets not being tests

### DIFF
--- a/apps/compression/CMakeLists.txt
+++ b/apps/compression/CMakeLists.txt
@@ -17,10 +17,4 @@ target_link_libraries(gys_compress
         gslx::utils
 )
 
-get_filename_component(PROJECT_ROOT_DIR ${CMAKE_SOURCE_DIR} ABSOLUTE)
-set(PYTHON_MODULE_PATH "${PROJECT_ROOT_DIR}/src/python")
-set_target_properties(gys_compress PROPERTIES
-    ENVIRONMENT "PYTHONPATH=${PYTHON_MODULE_PATH}:$ENV{PYTHONPATH}"
-)
-
 install(TARGETS gys_compress)

--- a/apps/io/CMakeLists.txt
+++ b/apps/io/CMakeLists.txt
@@ -14,11 +14,4 @@ target_link_libraries(gys_io
         MPI::MPI_CXX
 )
 
-# Set PYTHONPATH to include the python directory for Python module imports
-get_filename_component(PROJECT_ROOT_DIR ${CMAKE_SOURCE_DIR} ABSOLUTE)
-set(PYTHON_MODULE_PATH "${PROJECT_ROOT_DIR}/src/python")
-set_target_properties(gys_io PROPERTIES
-    ENVIRONMENT "PYTHONPATH=${PYTHON_MODULE_PATH}:$ENV{PYTHONPATH}"
-)
-
 install(TARGETS gys_io)


### PR DESCRIPTION
It seems to me the property `ENVIRONMENT` only makes sense to test targets (defined with `add_test`), see https://cmake.org/cmake/help/latest/manual/cmake-properties.7.html#properties-on-tests. I don't think they make sense for regular targets.