### PR TITLE
Remove usage of global targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ set(GYSELALIBXX_BUILD_DOCUMENTATION OFF)
 #                              Build libraries and executables
 ###############################################################################################
 
-set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
-
 ## Link to Gyselalibxx++ library
 add_subdirectory(src/external/gyselalibxx)
 


### PR DESCRIPTION
~~This used to be a workaround for PDI. This is not an issue anymore and is a bad practice.~~

Required as long as we rely on `add_subdirectory(src/external/gyselalibxx)` to provide our dependencies.